### PR TITLE
bug-1: ya no se traba al darle doble click al item

### DIFF
--- a/src/components/MarvelCard.js
+++ b/src/components/MarvelCard.js
@@ -56,11 +56,15 @@ const MarvelCard = props => {
         if(now==='not-blocked'){
            setVisibilidad(true);
         }
-    }
+        console.log(estatus)
+    };
 
     if(estatus.includes(id)){
         setTimeout(()=>setVisibilidad(false),1100);
     }
+
+
+
 
     return (
         <div>

--- a/src/components/MarvelList.js
+++ b/src/components/MarvelList.js
@@ -87,7 +87,6 @@ class MarvelList extends React.Component {
     }
 
     agregarCarta = async(nombre,id) => {
-
         if(!this.state.idSeleccionados.includes(id) & !this.state.usados.includes(id)){
             switch (this.state.seleccion.length) {
                 case 0:
@@ -104,26 +103,28 @@ class MarvelList extends React.Component {
                         //ganaste
                         this.state.usados.push(this.state.idSeleccionados[0])
                         this.state.usados.push(this.state.idSeleccionados[1])
+                        this.setState({
+                            seleccion: [],
+                            idSeleccionados: []
+                        }); 
                     }else{
                     //elige de nuevo
-                        if(this.state.intentos>5){
+                        if(this.state.intentos>4){
                             console.log('Game Over');
                             this.props.actualizar('lost')
                         }else{
                             this.state.estatusJuego.push(...this.state.idSeleccionados)
+                            setTimeout(()=>{this.setState({estatusJuego:[]})},1000)
                             this.setState({
-                                now:'blocked',
-                                intentos: this.state.intentos+1
+                                //now:'blocked',
+                                intentos: this.state.intentos+1,
+                                seleccion: [],
+                                idSeleccionados: []
                             })
                         }    
                     }
-                    this.setState({
-                        seleccion: [],
-                        idSeleccionados: []
-                    });
-                    setTimeout(()=>{this.setState({now:'not-blocked'})},1500)
-                    
                     break;
+
                 default:
                     break;
             }


### PR DESCRIPTION
Antes se trababa al darle doble click muy rápido al mismo item.

El problema era que estabamos haciendo el volteo de las cartas con un condicional que se ejecutaba cada vez que la carta sufría algún cambio por lo tanto, cuando voletabamos boca abajo dos cartas que no eran iguales, entonces esta llamada se ejecutaba dos veces y como estabamos usando un setTimeout, la segunda vez que lo volteabas hacia arriba entraba la segunda llamada rezagada y lo volvía a poner boca abajo. 

La solución fue utilizar un setTimeout al momento que agregabamos los id que debemos poner boca abajo para eliminarlos después de 1 segundo, con esto a pesar que se llama al condicional dos veces el test no pasa porque los id ya han sido eliminados de la lista