### PR TITLE
bug de bloquear cartas cuando ya tenemos 2

### DIFF
--- a/src/components/MarvelCard.js
+++ b/src/components/MarvelCard.js
@@ -56,7 +56,6 @@ const MarvelCard = props => {
         if(now==='not-blocked'){
            setVisibilidad(true);
         }
-        console.log(estatus)
     };
 
     if(estatus.includes(id)){

--- a/src/components/MarvelList.js
+++ b/src/components/MarvelList.js
@@ -87,7 +87,7 @@ class MarvelList extends React.Component {
     }
 
     agregarCarta = async(nombre,id) => {
-        if(!this.state.idSeleccionados.includes(id) & !this.state.usados.includes(id)){
+        if(!this.state.idSeleccionados.includes(id) & !this.state.usados.includes(id) & this.state.now==='not-blocked'){
             switch (this.state.seleccion.length) {
                 case 0:
                     this.setState({
@@ -114,13 +114,14 @@ class MarvelList extends React.Component {
                             this.props.actualizar('lost')
                         }else{
                             this.state.estatusJuego.push(...this.state.idSeleccionados)
-                            setTimeout(()=>{this.setState({estatusJuego:[]})},1000)
+                            setTimeout(()=>{this.setState({estatusJuego:[],now:'not-blocked'})},1100)
                             this.setState({
-                                //now:'blocked',
+                                now:'blocked',
                                 intentos: this.state.intentos+1,
                                 seleccion: [],
                                 idSeleccionados: []
-                            })
+                            });
+                            
                         }    
                     }
                     break;


### PR DESCRIPTION
En el merge anterior habiamos deshabilitado el estado 'block'/'not-blocked' que permite que no se puedan seleccionar más de dos cartas al mismo tiempo. En este nuevo merge se corrige esa funcionalidad.